### PR TITLE
Dockerfile without multi-stage build

### DIFF
--- a/Dockerfile.nomulti
+++ b/Dockerfile.nomulti
@@ -1,0 +1,14 @@
+# This Dockerfile is intended to be used to build with Docker versions prior to 17.06 CE
+# or with custom Docker distribution like the ones found in Fedora, RHEL or CentOS where
+# the multi-stage build is not already supported.
+
+FROM golang:1.9.4
+WORKDIR /go
+ENV GOOS=linux
+ENV CGO_ENABLED=0
+ENV GOPATH=/go
+COPY ./main.go .
+RUN go build -o grafana-ambassador main.go
+RUN mv grafana-ambassador /usr/bin/grafana-ambassador && rm -f main.go
+
+ENTRYPOINT ["/usr/bin/grafana-ambassador"]

--- a/Dockerfile.nomulti
+++ b/Dockerfile.nomulti
@@ -8,7 +8,7 @@ ENV GOOS=linux
 ENV CGO_ENABLED=0
 ENV GOPATH=/go
 COPY ./main.go .
-RUN go build -o grafana-ambassador main.go
-RUN mv grafana-ambassador /usr/bin/grafana-ambassador && rm -f main.go
+RUN go build -o grafana-ambassador main.go && rm -f main.go
+RUN mv grafana-ambassador /usr/bin/grafana-ambassador
 
 ENTRYPOINT ["/usr/bin/grafana-ambassador"]

--- a/main.go
+++ b/main.go
@@ -89,5 +89,5 @@ func main() {
 
 	http.HandleFunc("/", proxy)
 	// TODO: enabling listening only on loopback
-	http.ListenAndServe(":9090", nil)
+	log.Fatal(http.ListenAndServe(":9090", nil))
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -8,8 +10,6 @@ import (
 	"net/http"
 	"os"
 	"time"
-	"crypto/tls"
-	"crypto/x509"
 )
 
 var (
@@ -44,11 +44,13 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 		log.Fatal(err)
 	}
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
+	if parseOk := caCertPool.AppendCertsFromPEM(caCert); !parseOk {
+		log.Fatal("Error parsing service account CA certificate")
+	}
 
 	// Setup HTTPS client
 	tlsConfig := &tls.Config{
-		RootCAs: caCertPool,
+		RootCAs:            caCertPool,
 		InsecureSkipVerify: *skipInsecure != "",
 	}
 	tlsConfig.BuildNameToCertificate()

--- a/main.go
+++ b/main.go
@@ -73,6 +73,8 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 // Setup logger interface and provide a simple validation: if everything is fine start serving :9090
 // (Prometheus standard port and binding on loopback due to Pod network share according to Ambassador pattern)
 func main() {
+	flag.Parse()
+
 	log.SetFlags(0)
 	log.SetOutput(new(logWriter))
 

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ type logWriter struct {
 }
 
 // Formatting the logger interface according to customer needs: feel free to edit
-func (writer logWriter) Write(bytes []byte) (int, error) {
+func (writer *logWriter) Write(bytes []byte) (int, error) {
 	return fmt.Print(time.Now().UTC().Format("2006-01-02 15:05:05.000-0700") + " ERROR [proxy] (prometheus) " + string(bytes))
 }
 


### PR DESCRIPTION
Added a Dockerfile with no multi-stage build.
This Dockerfile is intended to be used to build with Docker versions prior to 17.06 CE or with custom Docker distribution like the ones found in Fedora, RHEL or CentOS where the multi-stage build is not already supported.
Quite simple and minimal, could be improved a lot but it does the job.
